### PR TITLE
Create default Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of Conduct] when discussing the project on the available communication channels.
+
+## Moderation
+
+Any questions, concerns, or moderation requests please e-mail a moderator.
+
+- Ross A. Baker | [email](mailto:ross@rossabaker.com)
+- Christopher Davenport | [email](mailto:chris@christopherdavenport.tech)
+- Kailuo Wang | [email](mailto:kailuo.wang@gmail.com)
+
+And of course, always feel free to reach out to anyone with the **mods** role in [Discord](https://discord.gg/QNnHKHq5Ts).
+
+[Scala Code of Conduct]: https://typelevel.org/code-of-conduct.html


### PR DESCRIPTION
Most Typelevel repositories have something like this.  GitHub uses this as a "default project health" file, so we can DRY it up and keep the moderators current as they change.