### PR TITLE
Remove @rossabaker as moderator

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,6 @@ Everyone is expected to follow the [Scala Code of Conduct] when discussing the p
 
 Any questions, concerns, or moderation requests please e-mail a moderator.
 
-- Ross A. Baker | [email](mailto:ross@rossabaker.com)
 - Christopher Davenport | [email](mailto:chris@christopherdavenport.tech)
 - Kailuo Wang | [email](mailto:kailuo.wang@gmail.com)
 


### PR DESCRIPTION
I joined in a mod shortage, when I was on chat.  Now we have new mods and I'm not on chat.  I leave this team in good hands.