### PR TITLE
Add instructions for private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,12 @@
 
 ## Reporting a Security Issue
 
-To report a security issue, please email [security@typelevel.org](mailto:security@typelevel.org) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.  The Security Team will attempt to respond within 3 working days of your email.  If the issue is confirmed as a vulnerability, we will open a Security Advisory.  This project follows a 90 day disclosure timeline.
+To report a security issue, please use one of the following methods:
+
+1. Navigate to the "Security and quality" tab at the top of this repository, click the "Report a vulnerability" button, and complete the form as much as possible.
+2. Email security@typelevel.org with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Security Team](#typelevel-security-team) will attempt to respond within 3 working days of your report.  If the issue is confirmed as a vulnerability, we will open a Security Advisory.  This project follows a 90 day disclosure timeline.
 
 ## Procedure
 


### PR DESCRIPTION
I have enabled [private security reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability) with an org-wide configuration for public repositories. Closes https://github.com/typelevel/tsc/issues/74.

I added instructions to use this (as an alternative to email) to our security policy. Unfortunately, there is no convenient way to link directly to the vulnerability report form (since the URL is specific to the repository and the policy is shared).