### PR TITLE
Link to contact section of CoC instead of listing names

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,14 +6,8 @@ Everyone is expected to follow the [Typelevel Code of Conduct] when discussing t
 
 ## Moderation
 
-If you have any questions, concerns, or moderation requests, please contact a moderator.
-
-- Sam Pillsworth | [email](mailto:sam@blerf.ca)
-- Andrew Valencik | [email](mailto:andrew.valencik@gmail.com)
-- Kateu Herbert | [email](mailto:hkateu@gmail.com)
-- Arman Bilge | [email](mailto:armanbilge@gmail.com)
-- Lucas Satabin | [email](mailto:lucas.satabin@gnieh.org)
-
-And of course, always feel free to reach out to anyone with the **mods** role in [Discord](https://discord.gg/QNnHKHq5Ts).
+If you have any questions, concerns, or moderation requests, please [contact the Code of Conduct Committee][contact] or feel free to reach out to anyone with the **mods** role on the [Typelevel Discord server][discord].
 
 [Typelevel Code of Conduct]: https://typelevel.org/code-of-conduct.html
+[contact]: https://typelevel.org/code-of-conduct/#contact
+[discord]: https://discord.gg/typelevel-632277896739946517

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,12 +2,12 @@
 
 Every member of our community has the right to have their identity respected. The Typelevel community is dedicated to providing a positive experience for everyone, regardless of age, gender identity and expression, sexual orientation, disability, neurodivergence, physical appearance, body size, ethnicity, nationality, race, or religion (or lack thereof), education, or socio-economic status.
 
-Everyone is expected to follow the [Typelevel Code of Conduct] when discussing the project on the available communication channels.
+Everyone is expected to follow the [Typelevel Code of Conduct][coc] when discussing the project on the available communication channels.
 
 ## Moderation
 
 If you have any questions, concerns, or moderation requests, please [contact the Code of Conduct Committee][contact] or feel free to reach out to anyone with the **mods** role on the [Typelevel Discord server][discord].
 
-[Typelevel Code of Conduct]: https://typelevel.org/code-of-conduct.html
+[coc]: https://typelevel.org/code-of-conduct/
 [contact]: https://typelevel.org/code-of-conduct/#contact
 [discord]: https://discord.gg/typelevel-632277896739946517


### PR DESCRIPTION
I am trying to reduce the number of "sources of truth" for up-to-date information about CoC contacts. In this case, I think it makes sense to link to the website.